### PR TITLE
Clean up unused UserName property in RegisterViewModel

### DIFF
--- a/ViewModels/RegisterViewModel.cs
+++ b/ViewModels/RegisterViewModel.cs
@@ -15,9 +15,6 @@ namespace EdufyAPI.ViewModels
         [Display(Name = "Email")]
         public string Email { get; set; }
 
-        //[Required]
-        //[Display(Name = "Username")]
-        //public string UserName { get; set; }
 
         [Required]
         [MinLength(6)]


### PR DESCRIPTION
Removed commented-out code for the UserName property, including the `[Required]` and `[Display(Name = "Username")]` attributes. This cleanup reflects that the UserName property is no longer needed in the RegisterViewModel class.